### PR TITLE
Fix CI issues

### DIFF
--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -1,5 +1,5 @@
 /*
-Copyright The cert-manager Authors.
+Copyright 2020 The cert-manager Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/internal/pki/cert_pool.go
+++ b/internal/pki/cert_pool.go
@@ -1,5 +1,5 @@
 /*
-Copyright The cert-manager Authors.
+Copyright 2022 The cert-manager Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/internal/pki/csr.go
+++ b/internal/pki/csr.go
@@ -1,5 +1,5 @@
 /*
-Copyright The cert-manager Authors.
+Copyright 2020 The cert-manager Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/internal/pki/csr.go
+++ b/internal/pki/csr.go
@@ -114,7 +114,7 @@ func EncodeX509(cert *x509.Certificate) ([]byte, error) {
 func signatureAlgorithmFromPublicKey(alg x509.PublicKeyAlgorithm, arg any) (x509.SignatureAlgorithm, error) {
 	var signatureAlgorithm x509.SignatureAlgorithm
 
-	switch alg {
+	switch alg { //nolint:exhaustive // There is a default that appears to be not picked up by the linter
 	case x509.RSA:
 		size, ok := arg.(int)
 		if !ok {

--- a/internal/pki/generate.go
+++ b/internal/pki/generate.go
@@ -1,5 +1,5 @@
 /*
-Copyright The cert-manager Authors.
+Copyright 2020 The cert-manager Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/internal/pki/parse.go
+++ b/internal/pki/parse.go
@@ -1,5 +1,5 @@
 /*
-Copyright The cert-manager Authors.
+Copyright 2020 The cert-manager Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 
-	"github.com/cert-manager/webhook-cert-lib/internal/pki/errors"
+	"github.com/cert-manager/webhook-cert-lib/internal/errors"
 )
 
 // DecodeX509CertificateBytes will decode a PEM encoded x509 Certificate.

--- a/pkg/authority/api/api.go
+++ b/pkg/authority/api/api.go
@@ -24,16 +24,16 @@ const (
 	// `inject-dynamic-ca-from-secret` label.
 	// If an injectable references a Secret that does NOT have this annotation,
 	// the dynamic ca-injector will refuse to inject the secret.
-	DynamicAuthoritySecretLabel = "cert-manager.io/allow-dynamic-ca-injection"
+	DynamicAuthoritySecretLabel = "cert-manager.io/allow-dynamic-ca-injection" //#nosec G101 - This is not credentials
 	// WantInjectFromSecretNamespaceLabel is the label that specifies that a
 	// particular object wants injection of dynamic CAs from secret in
 	// namespace.
 	// Must be used in conjunction with WantInjectFromSecretNameLabel.
-	WantInjectFromSecretNamespaceLabel = "cert-manager.io/inject-dynamic-ca-from-secret-namespace"
+	WantInjectFromSecretNamespaceLabel = "cert-manager.io/inject-dynamic-ca-from-secret-namespace" //#nosec G101 - This is not credentials
 	// WantInjectFromSecretNameLabel is the label that specifies that a
 	// particular object wants injection of dynamic CAs from secret with name.
 	// Must be used in conjunction with WantInjectFromSecretNamespaceLabel.
-	WantInjectFromSecretNameLabel = "cert-manager.io/inject-dynamic-ca-from-secret-name"
+	WantInjectFromSecretNameLabel = "cert-manager.io/inject-dynamic-ca-from-secret-name" //#nosec G101 - This is not credentials
 
 	// TLSCABundleKey is used as a data key in Secret resources to store a CA
 	// certificate bundle.
@@ -42,9 +42,9 @@ const (
 	// RenewCertificateSecretAnnotation is an annotation that can be set to
 	// an arbitrary value on a certificate secret to trigger a renewal of the
 	// certificate managed in the secret.
-	RenewCertificateSecretAnnotation = "renew.cert-manager.io/requestedAt"
+	RenewCertificateSecretAnnotation = "renew.cert-manager.io/requestedAt" //#nosec G101 - This is not credentials
 	// RenewHandledCertificateSecretAnnotation is an annotation that will be set on a
 	// certificate secret whenever a new certificate is renewed using the
 	// RenewCertificateSecretAnnotation annotation.
-	RenewHandledCertificateSecretAnnotation = "renew.cert-manager.io/lastRequestedAt"
+	RenewHandledCertificateSecretAnnotation = "renew.cert-manager.io/lastRequestedAt" //#nosec G101 - This is not credentials
 )

--- a/pkg/authority/api/api.go
+++ b/pkg/authority/api/api.go
@@ -1,5 +1,5 @@
 /*
-Copyright The cert-manager Authors.
+Copyright 2025 The cert-manager Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/authority/authority.go
+++ b/pkg/authority/authority.go
@@ -1,5 +1,5 @@
 /*
-Copyright The cert-manager Authors.
+Copyright 2025 The cert-manager Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/authority/authority.go
+++ b/pkg/authority/authority.go
@@ -21,10 +21,6 @@ import (
 	"errors"
 	"time"
 
-	"github.com/cert-manager/webhook-cert-lib/pkg/authority/api"
-	"github.com/cert-manager/webhook-cert-lib/pkg/authority/cert"
-	leadercontrollers "github.com/cert-manager/webhook-cert-lib/pkg/authority/leader_controllers"
-	"github.com/cert-manager/webhook-cert-lib/pkg/authority/leader_controllers/injectable"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/fields"
@@ -32,6 +28,11 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/cert-manager/webhook-cert-lib/pkg/authority/api"
+	"github.com/cert-manager/webhook-cert-lib/pkg/authority/cert"
+	leadercontrollers "github.com/cert-manager/webhook-cert-lib/pkg/authority/leader_controllers"
+	"github.com/cert-manager/webhook-cert-lib/pkg/authority/leader_controllers/injectable"
 )
 
 type LeafOptions struct {

--- a/pkg/authority/cert/tls.go
+++ b/pkg/authority/cert/tls.go
@@ -1,5 +1,5 @@
 /*
-Copyright The cert-manager Authors.
+Copyright 2025 The cert-manager Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/authority/leader_controllers/ca_secret_controller.go
+++ b/pkg/authority/leader_controllers/ca_secret_controller.go
@@ -21,6 +21,7 @@ import (
 	"crypto"
 	"crypto/x509"
 
+	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -35,7 +36,6 @@ import (
 	"github.com/cert-manager/webhook-cert-lib/internal/pki"
 	"github.com/cert-manager/webhook-cert-lib/pkg/authority/api"
 	"github.com/cert-manager/webhook-cert-lib/pkg/authority/cert"
-	"github.com/go-logr/logr"
 )
 
 // CASecretReconciler reconciles a CA Secret object

--- a/pkg/authority/leader_controllers/ca_secret_controller.go
+++ b/pkg/authority/leader_controllers/ca_secret_controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright The cert-manager Authors.
+Copyright 2025 The cert-manager Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/authority/leader_controllers/injectable/injectable.go
+++ b/pkg/authority/leader_controllers/injectable/injectable.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2025 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package injectable
 
 import (

--- a/pkg/authority/leader_controllers/injectable/validating_webhook.go
+++ b/pkg/authority/leader_controllers/injectable/validating_webhook.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2025 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package injectable
 
 import (

--- a/pkg/authority/leader_controllers/injectable_controller.go
+++ b/pkg/authority/leader_controllers/injectable_controller.go
@@ -20,8 +20,6 @@ import (
 	"context"
 	"strings"
 
-	"github.com/cert-manager/webhook-cert-lib/pkg/authority/api"
-	"github.com/cert-manager/webhook-cert-lib/pkg/authority/leader_controllers/injectable"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -33,6 +31,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	"github.com/cert-manager/webhook-cert-lib/pkg/authority/api"
+	"github.com/cert-manager/webhook-cert-lib/pkg/authority/leader_controllers/injectable"
 )
 
 // InjectableReconciler injects CA bundle into resources
@@ -69,11 +70,11 @@ func (r *InjectableReconciler) SetupWithManager(mgr ctrl.Manager) error {
 					}
 
 					requests := make([]reconcile.Request, len(objList.Items))
-					for _, obj := range objList.Items {
+					for i, obj := range objList.Items {
 						req := reconcile.Request{}
 						req.Namespace = obj.GetNamespace()
 						req.Name = obj.GetName()
-						requests = append(requests, req)
+						requests[i] = req
 					}
 					return requests
 				}),

--- a/pkg/authority/leader_controllers/injectable_controller.go
+++ b/pkg/authority/leader_controllers/injectable_controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright The cert-manager Authors.
+Copyright 2025 The cert-manager Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/authority/leader_controllers/reconciler.go
+++ b/pkg/authority/leader_controllers/reconciler.go
@@ -1,5 +1,5 @@
 /*
-Copyright The cert-manager Authors.
+Copyright 2025 The cert-manager Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/authority/leader_controllers/ssa_client.go
+++ b/pkg/authority/leader_controllers/ssa_client.go
@@ -17,10 +17,11 @@ limitations under the License.
 package leadercontrollers
 
 import (
-	"github.com/cert-manager/webhook-cert-lib/pkg/authority/leader_controllers/injectable"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/json"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/cert-manager/webhook-cert-lib/pkg/authority/leader_controllers/injectable"
 )
 
 const (

--- a/pkg/authority/leader_controllers/ssa_client.go
+++ b/pkg/authority/leader_controllers/ssa_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright The cert-manager Authors.
+Copyright 2025 The cert-manager Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/authority/leaf_cert_controller.go
+++ b/pkg/authority/leaf_cert_controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright The cert-manager Authors.
+Copyright 2025 The cert-manager Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/ca_secret_controller_test.go
+++ b/test/ca_secret_controller_test.go
@@ -19,9 +19,6 @@ package test
 import (
 	"time"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -32,6 +29,9 @@ import (
 	"github.com/cert-manager/webhook-cert-lib/internal/pki"
 	"github.com/cert-manager/webhook-cert-lib/pkg/authority/api"
 	leadercontrollers "github.com/cert-manager/webhook-cert-lib/pkg/authority/leader_controllers"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("CA Secret Controller", Ordered, func() {

--- a/test/ca_secret_controller_test.go
+++ b/test/ca_secret_controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright The cert-manager Authors.
+Copyright 2025 The cert-manager Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/injectable_controller_test.go
+++ b/test/injectable_controller_test.go
@@ -17,12 +17,6 @@ limitations under the License.
 package test
 
 import (
-	"github.com/cert-manager/webhook-cert-lib/pkg/authority/api"
-	"github.com/cert-manager/webhook-cert-lib/pkg/authority/leader_controllers/injectable"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-
-	leadercontrollers "github.com/cert-manager/webhook-cert-lib/pkg/authority/leader_controllers"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -31,6 +25,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest/komega"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+
+	"github.com/cert-manager/webhook-cert-lib/pkg/authority/api"
+	leadercontrollers "github.com/cert-manager/webhook-cert-lib/pkg/authority/leader_controllers"
+	"github.com/cert-manager/webhook-cert-lib/pkg/authority/leader_controllers/injectable"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Injectable Controller", Ordered, func() {

--- a/test/injectable_controller_test.go
+++ b/test/injectable_controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright The cert-manager Authors.
+Copyright 2025 The cert-manager Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/leaf_cert_controller_test.go
+++ b/test/leaf_cert_controller_test.go
@@ -20,9 +20,6 @@ import (
 	"crypto/tls"
 	"time"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -35,6 +32,9 @@ import (
 	"github.com/cert-manager/webhook-cert-lib/pkg/authority/api"
 	"github.com/cert-manager/webhook-cert-lib/pkg/authority/cert"
 	leadercontrollers "github.com/cert-manager/webhook-cert-lib/pkg/authority/leader_controllers"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Leaf Certificate Controller", Ordered, func() {

--- a/test/leaf_cert_controller_test.go
+++ b/test/leaf_cert_controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright The cert-manager Authors.
+Copyright 2025 The cert-manager Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -20,9 +20,6 @@ import (
 	"context"
 	"testing"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -30,6 +27,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest/komega"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to

--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright The cert-manager Authors.
+Copyright 2025 The cert-manager Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/util_test.go
+++ b/test/util_test.go
@@ -20,8 +20,6 @@ import (
 	"errors"
 	"fmt"
 
-	. "github.com/onsi/gomega"
-
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -30,6 +28,8 @@ import (
 
 	"github.com/cert-manager/webhook-cert-lib/internal/pki"
 	"github.com/cert-manager/webhook-cert-lib/pkg/authority/api"
+
+	. "github.com/onsi/gomega"
 )
 
 func assertCASecret(secret *corev1.Secret) {

--- a/test/util_test.go
+++ b/test/util_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright The cert-manager Authors.
+Copyright 2025 The cert-manager Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
This PR fixes the reported errors by golangci-lint and our boilerplate checker.

````
$ make verify
/home/erikbo/projects/github/cert-manager-webhook-cert-lib/_bin/tools/boilersuite .
make/_shared/generate-verify//util/verify.sh make generate-base
make[1]: Entering directory '/tmp/verify.sh.BRqOkuZJ'
cp -r make/_shared/repository-base//base//. ./
cp -r make/_shared/repository-base//base-dependabot//. ./
make[1]: Leaving directory '/tmp/verify.sh.BRqOkuZJ'
make/_shared/generate-verify//util/verify.sh make generate-go-mod-tidy
make[1]: Entering directory '/tmp/verify.sh.hQ2w8FD6'
Running 'go mod tidy' in directory './test'

Running 'go mod tidy' in directory '.'

make[1]: Leaving directory '/tmp/verify.sh.hQ2w8FD6'
make/_shared/generate-verify//util/verify.sh make generate-golangci-lint-config
make[1]: Entering directory '/tmp/verify.sh.7MVh1AvC'
mkdir -p _bin/scratch
if [ "$(/tmp/verify.sh.7MVh1AvC/_bin/tools/yq eval 'has("version") | not' .golangci.yaml)" == "true" ]; then \
        /tmp/verify.sh.7MVh1AvC/_bin/tools/golangci-lint migrate -c .golangci.yaml; \
        rm .golangci.bck.yaml; \
fi
cp .golangci.yaml _bin/scratch/golangci-lint.yaml.tmp
/tmp/verify.sh.7MVh1AvC/_bin/tools/yq -i 'del(.linters.enable)' _bin/scratch/golangci-lint.yaml.tmp
/tmp/verify.sh.7MVh1AvC/_bin/tools/yq eval-all -i '. as $item ireduce ({}; . * $item)' _bin/scratch/golangci-lint.yaml.tmp make/_shared/go//.golangci.override.yaml
/tmp/verify.sh.7MVh1AvC/_bin/tools/yq -i '(.. | select(tag == "!!str")) |= sub("{{REPO-NAME}}", "github.com/cert-manager/webhook-cert-lib")' _bin/scratch/golangci-lint.yaml.tmp
mv _bin/scratch/golangci-lint.yaml.tmp .golangci.yaml
make[1]: Leaving directory '/tmp/verify.sh.7MVh1AvC'
make/_shared/generate-verify//util/verify.sh make generate-govulncheck
make[1]: Entering directory '/tmp/verify.sh.CarpXLn4'
cp -r make/_shared/go//base//. ./
make[1]: Leaving directory '/tmp/verify.sh.CarpXLn4'
make/_shared/generate-verify//util/verify.sh make generate-klone
make[1]: Entering directory '/tmp/verify.sh.txcwfv5a'
mkdir -p _bin/scratch
/tmp/verify.sh.txcwfv5a/_bin/tools/klone sync
make[1]: Leaving directory '/tmp/verify.sh.txcwfv5a'
The following targets create temporary files in the current directory, that is why they have to be run last:
make verify-golangci-lint
make[1]: Entering directory '/home/erikbo/projects/github/cert-manager-webhook-cert-lib'
Running 'GOVERSION=1.24.4 _bin/tools/golangci-lint run -c /home/erikbo/projects/github/cert-manager-webhook-cert-lib/.golangci.yaml --timeout 10m' in directory './test'
WARN [runner/exclusion_paths] The pattern "third_party" match no issues 
WARN [runner/exclusion_paths] The pattern "builtin$" match no issues 
WARN [runner/exclusion_paths] The pattern "examples$" match no issues 
WARN [runner/exclusion_rules] Skipped 0 issues by rules: [Path: "third_party", Linters: "gci, gofmt"] 
WARN [runner/exclusion_rules] Skipped 0 issues by rules: [Path: "builtin$", Linters: "gci, gofmt"] 
WARN [runner/exclusion_rules] Skipped 0 issues by rules: [Path: "examples$", Linters: "gci, gofmt"] 
0 issues.

Running 'GOVERSION=1.24.4 _bin/tools/golangci-lint run -c /home/erikbo/projects/github/cert-manager-webhook-cert-lib/.golangci.yaml --timeout 10m' in directory '.'
WARN [runner/exclusion_paths] The pattern "third_party" match no issues 
WARN [runner/exclusion_paths] The pattern "builtin$" match no issues 
WARN [runner/exclusion_paths] The pattern "examples$" match no issues 
WARN [runner/exclusion_rules] Skipped 0 issues by rules: [Path: "third_party", Linters: "gci, gofmt"] 
WARN [runner/exclusion_rules] Skipped 0 issues by rules: [Path: "builtin$", Linters: "gci, gofmt"] 
WARN [runner/exclusion_rules] Skipped 0 issues by rules: [Path: "examples$", Linters: "gci, gofmt"] 
0 issues.

make[1]: Leaving directory '/home/erikbo/projects/github/cert-manager-webhook-cert-lib'
````