### PR TITLE
Add dummy test-e2e target to enable CI

### DIFF
--- a/make/test-e2e.mk
+++ b/make/test-e2e.mk
@@ -1,4 +1,4 @@
-# Copyright 2023 The cert-manager Authors.
+# Copyright 2025 The cert-manager Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,5 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-include make/test-unit.mk
-include make/test-e2e.mk
+
+.PHONY: test-e2e
+## Run end-to-end tests
+## @category Testing
+test-e2e:
+	# TODO: Create e2e-tests and make them run from here.


### PR DESCRIPTION
This adds a dummy make target for our future e2e tests.

Blocks https://github.com/cert-manager/testing/pull/1098.