### PR TITLE
Add make generate to Renovate allowed commands

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -13,6 +13,9 @@
   labels: [
     'dependencies',
   ],
+  allowedCommands: [
+    'make generate',
+  ],
   postUpgradeTasks: {
     commands: [
       'make generate',


### PR DESCRIPTION
I am testing the Renovate GH App in this project, and we need to allow Renovate to run the `make generate` command. In the Renovate workflow setup, this is configured in the workflow, ref. https://github.com/cert-manager/webhook-cert-lib/pull/41.